### PR TITLE
feat: Brain Engine v0.6.6 - Multi-format loader, Procedures, Version fix

### DIFF
--- a/bin/brain-engine.js
+++ b/bin/brain-engine.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Brain Engine CLI
+ * 
+ * Unified loader CLI for VANT brains
+ * 
+ * Usage:
+ *   node bin/brain-engine.js discover
+ *   node bin/brain-engine.js load v0.5.0
+ *   node bin/brain-engine.js graph
+ *   node bin/brain-engine.js delta v0.5.0 v0.8.0
+ *   node bin/brain-engine.js render --needs identity,memories
+ *   node bin/brain-engine.js keeper-verify
+ *   node bin/brain-engine.js cache-status
+ */
+
+const engine = require('../lib/brain-engine');
+const args = process.argv.slice(2);
+
+async function main() {
+    const command = args[0];
+    
+    switch (command) {
+        case 'discover':
+        case 'list':
+            console.log('🧠 Brain Engine - Discovered Brains\n');
+            const brains = engine.discoverBrains();
+            brains.forEach((b, i) => {
+                const marker = i === brains.length - 1 ? '👉 ' : '   ';
+                console.log(`${marker}${b.name} (${b.format})`);
+            });
+            console.log(`\nTotal: ${brains.length} brains`);
+            break;
+            
+        case 'load':
+            const version = args[1] || 'latest';
+            console.log('🧠 Brain Engine - Loading\n');
+            const brain = version === 'latest' ? engine.loadLatest() : engine.loadBrain(version);
+            console.log(`Loaded: ${brain.version}`);
+            console.log(`Format: ${brain.format}`);
+            console.log(`Identity: ${brain.identity ? 'yes' : 'no'}`);
+            console.log(`Files: ${Object.keys(brain.files).length}`);
+            console.log(`Categories: learnings(${Object.keys(brain.categories.learnings).length}), memories(${Object.keys(brain.categories.memories).length})`);
+            engine.cacheBrain(brain);
+            break;
+            
+        case 'graph':
+            console.log('🧠 Brain Engine - Version Graph\n');
+            const graph = engine.getGraph();
+            console.log('Nodes:', graph.nodes.map(n => n.name).join(', '));
+            if (graph.edges.length > 0) {
+                console.log('\nEdges:');
+                graph.edges.forEach(e => console.log(`  ${e.from} → ${e.to}`));
+            }
+            break;
+            
+        case 'delta':
+            const from = args[1];
+            const to = args[2];
+            if (!from || !to) {
+                console.log('Usage: node bin/brain-engine.js delta <from-version> <to-version>');
+                process.exit(1);
+            }
+            console.log('🧠 Brain Engine - Delta\n');
+            const delta = engine.computeDelta(from, to);
+            console.log(`From: ${delta.from} → To: ${delta.to}`);
+            console.log(`Added: ${Object.keys(delta.added).length}`);
+            console.log(`Modified: ${Object.keys(delta.modified).length}`);
+            console.log(`Removed: ${Object.keys(delta.removed).length}`);
+            break;
+            
+        case 'render':
+            const needsArg = args.find(a => a.startsWith('--needs='));
+            const needs = needsArg ? needsArg.replace('--needs=', '').split(',') : ['identity'];
+            console.log('🧠 Brain Engine - Render\n');
+            const rendered = engine.render({ needs });
+            console.log(`Needs: ${needs.join(', ')}`);
+            console.log(`Sources: ${Object.keys(rendered.sources).join(', ')}`);
+            console.log(`Identity: ${rendered.identity ? 'loaded' : 'none'}`);
+            console.log(`Learnings: ${Object.keys(rendered.learnings).length}`);
+            console.log(`Memories: ${Object.keys(rendered.memories).length}`);
+            break;
+            
+        case 'keeper-verify':
+        case 'verify':
+            console.log('🧠 Brain Engine - Keeper Verify\n');
+            const toVerify = args[1] || 'latest';
+            const vBrain = toVerify === 'latest' ? engine.loadLatest() : engine.loadBrain(toVerify);
+            engine.keeperVerify(vBrain);
+            break;
+            
+        case 'cache-status':
+            console.log('🧠 Brain Engine - Cache Status\n');
+            const failures = engine.getFailures();
+            console.log('Failures recorded:', Object.keys(failures).length);
+            Object.keys(failures).forEach(v => {
+                console.log(`  - ${v}: ${failures[v].error}`);
+            });
+            const cached = engine.getCachedBrain();
+            console.log('\nCached brain:', cached ? cached.version : 'none');
+            break;
+            
+        default:
+            console.log('🧠 Brain Engine - VANT Unified Loader');
+            console.log('');
+            console.log('Usage: node bin/brain-engine.js <command> [options]');
+            console.log('');
+            console.log('Commands:');
+            console.log('  discover, list           List all brain versions');
+            console.log('  load [version]           Load brain (or latest)');
+            console.log('  graph                   Show version relationships');
+            console.log('  delta <from> <to>        Compute diff between versions');
+            console.log('  render --needs=x,y        Compose brain from needs');
+            console.log('  keeper-verify [ver]      Security check brain');
+            console.log('  cache-status           Show cache/failures');
+    }
+}
+
+main().catch(err => {
+    console.error('Error:', err.message);
+    process.exit(1);
+});

--- a/bin/procedures.js
+++ b/bin/procedures.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Procedures CLI
+ * 
+ * Gated brain operations:
+ *   node bin/procedures.js merge <from> <to>
+ *   node bin/procedures.js trim <version> <category> --confirm=DELETE
+ *   node bin/procedures.js audit
+ */
+
+const { MergeBrains, TrimBrain, auditVersions } = require('../lib/procedures');
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+async function main() {
+    switch (command) {
+        case 'merge':
+            const from = args[1];
+            const to = args[2];
+            if (!from || !to) {
+                console.log('Usage: node bin/procedures.js merge <from-version> <to-version>');
+                console.log('  Preserves: graphs, deltas, insights, data');
+                console.log('');
+                console.log('Example: node bin/procedures.js merge v0.5.0 v0.6.0');
+                process.exit(1);
+            }
+            console.log('🧬 Merge Procedure');
+            console.log('');
+            const result = await MergeBrains(from, to, {
+                preserve: ['graphs', 'deltas', 'insights', 'data']
+            });
+            console.log('');
+            console.log('Done:', result.added.files.length + result.added.categories.length, 'items merged');
+            break;
+            
+        case 'trim':
+            const version = args[1];
+            const scope = args[2];
+            const confirm = args.find(a => a.startsWith('--confirm='))?.replace('--confirm=', '') || process.env.VANT_TRIM_CONFIRM;
+            
+            if (!version || !scope) {
+                console.log('Usage: node bin/procedures.js trim <version> <scope> [--confirm=DELETE]');
+                console.log('  scope: category, file, pattern');
+                console.log('');
+                console.log('Examples:');
+                console.log('  node bin/procedures.js trim v0.5.0 category --confirm=DELETE --target=learnings');
+                console.log('  node bin/procedures.js trim v0.5.0 file --confirm=DELETE --target=learnings/old.md');
+                console.log('  node bin/procedures.js trim v0.5.0 pattern --confirm=DELETE --pattern="^legacy"');
+                process.exit(1);
+            }
+            
+            // Parse target from --target= or last arg
+            const target = args.find(a => a.startsWith('--target='))?.replace('--target=', '') 
+                || args[3];
+            const pattern = args.find(a => a.startsWith('--pattern='))?.replace('--pattern=', '');
+            
+            console.log('✂️ Trim Procedure');
+            console.log('');
+            const trimResult = await TrimBrain(version, scope, { 
+                target, 
+                pattern,
+                confirm 
+            });
+            console.log('');
+            console.log('Done:', trimResult.deleted.length, 'items trimmed');
+            break;
+            
+        case 'audit':
+            console.log('📋 Version Audit');
+            console.log('');
+            const report = auditVersions();
+            console.log('Total brains:', report.totalBrains);
+            console.log('');
+            report.brains.forEach(b => {
+                const cats = b.categories.join(', ') || 'none';
+                console.log(`  ${b.name.padEnd(10)} ${cats} (${b.files.length} files)`);
+            });
+            console.log('');
+            if (report.issues.length > 0) {
+                console.log('⚠️  Issues:');
+                report.issues.forEach(i => console.log('   -', i));
+            } else {
+                console.log('✅ No version gaps detected');
+            }
+            break;
+            
+        default:
+            console.log('🧬 Procedures - VANT Brain Operations');
+            console.log('');
+            console.log('Usage: node bin/procedures.js <command> [options]');
+            console.log('');
+            console.log('Commands:');
+            console.log('  merge <from> <to>       Combine brains (gated)');
+            console.log('  trim <ver> <scope>    Delete parts (gated)');
+            console.log('  audit                 Version audit');
+            console.log('');
+            console.log('Gated operations require GITHUB_TOKEN or VANT_GATE_TOKEN');
+    }
+}
+
+main().catch(err => {
+    console.error('Error:', err.message);
+    process.exit(1);
+});

--- a/lib/brain-engine.js
+++ b/lib/brain-engine.js
@@ -1,0 +1,828 @@
+/**
+ * Brain Engine - Unified Loader for VANT Brains
+ * 
+ * Supports:
+ * - Multi-format: txt, json, yaml, markdown
+ * - Smart semver parsing (not string sort)
+ * - Delta computation between versions
+ * - Version graph/lineage tracking
+ * - Multi-brain composable rendering
+ * - Cache + arbitration for resilient loading
+ * - Keeper layer for security
+ * 
+ * Usage:
+ *   node bin/brain-engine.js discover
+ *   node bin/brain-engine.js load v0.5.0
+ *   node bin/brain-engine.js graph
+ *   node bin/brain-engine.js delta v0.5.0 v0.8.0
+ *   node bin/brain-engine.js render --needs identity,memories
+ *   node bin/brain-engine.js keeper-verify
+ *   node bin/brain-engine.js cache-status
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const yaml = require('yaml');
+
+const MODELS_DIR = path.join(__dirname, '..', 'models');
+const STATES_DIR = path.join(__dirname, '..', 'states');
+const CACHE_DIR = path.join(STATES_DIR, 'cache');
+const KEEPERS_DIR = path.join(STATES_DIR, 'keepers');
+const DELTAS_DIR = path.join(STATES_DIR, 'deltas');
+
+// Ensure directories exist
+[CACHE_DIR, KEEPERS_DIR, DELTAS_DIR].forEach(dir => {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+});
+
+let currentBrain = null;
+let currentVersion = null;
+
+// ============================================================
+// FORMAT PARSERS (with failsafes)
+// ============================================================
+
+/**
+ * Parse text format (key=value or flat text)
+ */
+function parseTxt(content, filePath) {
+    try {
+        const lines = content.trim().split('\n');
+        const result = { _raw: content };
+        
+        lines.forEach(line => {
+            line = line.trim();
+            if (!line || line.startsWith('#')) return;
+            
+            if (line.includes('=')) {
+                const [key, ...vals] = line.split('=');
+                result[key.trim()] = vals.join('=').trim();
+            } else {
+                result[`_line_${Object.keys(result).length}`] = line;
+            }
+        });
+        
+        return result;
+    } catch (e) {
+        warn('txt', filePath, e.message);
+        return { _raw: content, _error: e.message };
+    }
+}
+
+/**
+ * Parse JSON format
+ */
+function parseJson(content, filePath) {
+    try {
+        return JSON.parse(content);
+    } catch (e) {
+        warn('json', filePath, e.message);
+        return { _raw: content, _error: e.message };
+    }
+}
+
+/**
+ * Parse YAML format (with multiple documents)
+ */
+function parseYaml(content, filePath) {
+    try {
+        const docs = yaml.parseAllDocuments(content);
+        if (docs.length === 1) {
+            return docs[0].toJSON();
+        } else if (docs.length > 1) {
+            return docs.map(d => d.toJSON());
+        }
+        return { _raw: content };
+    } catch (e) {
+        warn('yaml', filePath, e.message);
+        return { _raw: content, _error: e.message };
+    }
+}
+
+/**
+ * Parse Markdown with optional frontmatter
+ */
+function parseMarkdown(content, filePath) {
+    try {
+        const result = { _raw: content };
+        
+        // Check for frontmatter
+        if (content.startsWith('---')) {
+            const endIdx = content.indexOf('---', 3);
+            if (endIdx > 0) {
+                const frontmatter = content.slice(3, endIdx).trim();
+                const body = content.slice(endIdx + 3).trim();
+                
+                try {
+                    result._frontmatter = parseYaml(frontmatter, filePath);
+                } catch (e) {
+                    result._frontmatter = { _raw: frontmatter };
+                }
+                result._body = body;
+            }
+        } else {
+            result._body = content;
+        }
+        
+        return result;
+    } catch (e) {
+        warn('md', filePath, e.message);
+        return { _raw: content, _error: e.message };
+    }
+}
+
+/**
+ * Warn with rainbow message when parser fails
+ */
+function warn(format, filePath, error) {
+    console.warn(`⚠ your ${format} failed bro, but I read it still, here's alert rainbow 🌈`);
+    console.warn(`   File: ${filePath}`);
+    console.warn(`   Error: ${error}`);
+}
+
+/**
+ * Auto-detect format and parse
+ */
+function parseBrainFile(filePath, content) {
+    const ext = path.extname(filePath).toLowerCase();
+    const basename = path.basename(filePath).toLowerCase();
+    
+    // Check extension
+    switch (ext) {
+        case '.txt':
+            return parseTxt(content, filePath);
+        case '.json':
+            return parseJson(content, filePath);
+        case '.yaml':
+        case '.yml':
+            return parseYaml(content, filePath);
+        case '.md':
+            return parseMarkdown(content, filePath);
+    }
+    
+    // Check basename for identity files
+    if (basename === 'identity.yaml' || basename === 'identity.yml') {
+        return parseYaml(content, filePath);
+    }
+    if (basename === 'identity.json') {
+        return parseJson(content, filePath);
+    }
+    if (basename === 'identity.txt' || basename === 'identity.md') {
+        return parseMarkdown(content, filePath);
+    }
+    if (basename === 'meta.json') {
+        return parseJson(content, filePath);
+    }
+    
+    // Default: try as text
+    return parseTxt(content, filePath);
+}
+
+// ============================================================
+// BRAIN DISCOVERY
+// ============================================================
+
+/**
+ * Smart semver comparison
+ */
+function compareVersions(a, b) {
+    // Extract version numbers
+    const parseVer = (v) => {
+        v = v.replace(/^v/, '');
+        const parts = v.split(/[.-]/);
+        return parts.map(p => {
+            const num = parseInt(p, 10);
+            return isNaN(num) ? 0 : num;
+        });
+    };
+    
+    const aParts = parseVer(a);
+    const bParts = parseVer(b);
+    
+    for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+        const aVal = aParts[i] || 0;
+        const bVal = bParts[i] || 0;
+        if (aVal !== bVal) return aVal - bVal;
+    }
+    return 0;
+}
+
+/**
+ * Discover all brain versions in models/
+ */
+function discoverBrains() {
+    if (!fs.existsSync(MODELS_DIR)) {
+        return [];
+    }
+    
+    const dirs = fs.readdirSync(MODELS_DIR).filter(d => {
+        const fullPath = path.join(MODELS_DIR, d);
+        return fs.statSync(fullPath).isDirectory() && d !== 'backup';
+    });
+    
+    // Sort by semver
+    dirs.sort(compareVersions);
+    
+    return dirs.map(d => ({
+        name: d,
+        path: path.join(MODELS_DIR, d),
+        isLatest: false,
+        format: detectFormat(d)
+    }));
+}
+
+/**
+ * Detect primary format of a brain version
+ */
+function detectFormat(versionDir) {
+    const brainPath = path.join(MODELS_DIR, versionDir);
+    if (!fs.existsSync(brainPath)) return 'unknown';
+    
+    const files = fs.readdirSync(brainPath);
+    
+    if (files.includes('identity.yaml') || files.includes('identity.yml')) return 'yaml';
+    if (files.includes('identity.json')) return 'json';
+    if (files.some(f => f.endsWith('.json') && f !== 'meta.json')) return 'json';
+    if (files.includes('identity.txt')) return 'txt';
+    if (files.includes('identity.md') || files.includes('README.md')) return 'markdown';
+    
+    // Check for category folders (v0.5.0+ structure)
+    const categories = ['learnings', 'memories', 'decisions', 'todos'];
+    if (categories.some(c => fs.existsSync(path.join(brainPath, c)))) return 'yaml+folders';
+    
+    return 'txt';
+}
+
+// ============================================================
+// BRAIN LOADING
+// ============================================================
+
+/**
+ * Load a brain version
+ */
+function loadBrain(version) {
+    const brainPath = path.join(MODELS_DIR, version);
+    
+    if (!fs.existsSync(brainPath)) {
+        throw new Error(`Brain not found: ${version}`);
+    }
+    
+    const brain = {
+        version,
+        format: detectFormat(version),
+        identity: null,
+        meta: null,
+        files: {},
+        categories: {
+            learnings: {},
+            memories: {},
+            decisions: {},
+            todos: {}
+        }
+    };
+    
+    // Load files from brain root
+    const rootFiles = fs.readdirSync(brainPath);
+    rootFiles.forEach(file => {
+        const filePath = path.join(brainPath, file);
+        if (fs.statSync(filePath).isDirectory()) return;
+        
+        const content = fs.readFileSync(filePath, 'utf8');
+        const key = path.basename(file, path.extname(file));
+        
+        brain.files[file] = content;
+        
+        // Extract identity and meta
+        if (file === 'identity.yaml' || file === 'identity.yml') {
+            brain.identity = parseYaml(content, filePath);
+        } else if (file === 'identity.json') {
+            brain.identity = parseJson(content, filePath);
+        } else if (file === 'identity.txt' || file === 'identity.md') {
+            brain.identity = parseMarkdown(content, filePath);
+        } else if (file === 'meta.json') {
+            brain.meta = parseJson(content, filePath);
+        }
+    });
+    
+    // Load category folders
+    const categories = ['learnings', 'memories', 'decisions', 'todos'];
+    categories.forEach(cat => {
+        const catPath = path.join(brainPath, cat);
+        if (fs.existsSync(catPath)) {
+            const files = fs.readdirSync(catPath);
+            files.forEach(file => {
+                if (!file.endsWith('.md')) return;
+                const content = fs.readFileSync(path.join(catPath, file), 'utf8');
+                const key = path.basename(file, '.md');
+                brain.categories[cat][key] = content;
+            });
+        }
+    });
+    
+    currentBrain = brain;
+    currentVersion = version;
+    
+    return brain;
+}
+
+/**
+ * Load latest brain
+ */
+function loadLatest() {
+    const brains = discoverBrains();
+    if (brains.length === 0) {
+        throw new Error('No brains found');
+    }
+    
+    const latest = brains[brains.length - 1];
+    return loadBrain(latest.name);
+}
+
+/**
+ * Get current brain
+ */
+function getCurrentBrain() {
+    return currentBrain;
+}
+
+/**
+ * Get current version
+ */
+function getCurrentVersion() {
+    return currentVersion;
+}
+
+// ============================================================
+// ARBITRATION LAYER (Cache + Fallback)
+// ============================================================
+
+/**
+ * Get cached brain
+ */
+function getCachedBrain() {
+    const cacheFile = path.join(CACHE_DIR, 'last-good.json');
+    if (fs.existsSync(cacheFile)) {
+        try {
+            return JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
+        } catch (e) {
+            return null;
+        }
+    }
+    return null;
+}
+
+/**
+ * Cache brain as last working
+ */
+function cacheBrain(brain) {
+    const cacheFile = path.join(CACHE_DIR, 'last-good.json');
+    fs.writeFileSync(cacheFile, JSON.stringify(brain, null, 2));
+    console.log('💾 Cached brain:', brain.version);
+}
+
+/**
+ * Record failure
+ */
+function recordFailure(version, error) {
+    const failureFile = path.join(CACHE_DIR, 'failures.json');
+    let failures = {};
+    
+    if (fs.existsSync(failureFile)) {
+        try {
+            failures = JSON.parse(fs.readFileSync(failureFile, 'utf8'));
+        } catch (e) {}
+    }
+    
+    failures[version] = {
+        error,
+        timestamp: new Date().toISOString()
+    };
+    
+    fs.writeFileSync(failureFile, JSON.stringify(failures, null, 2));
+    console.warn('⚠ Failure recorded:', version, error);
+}
+
+/**
+ * Get failures
+ */
+function getFailures() {
+    const failureFile = path.join(CACHE_DIR, 'failures.json');
+    if (fs.existsSync(failureFile)) {
+        try {
+            return JSON.parse(fs.readFileSync(failureFile, 'utf8'));
+        } catch (e) {
+            return {};
+        }
+    }
+    return {};
+}
+
+/**
+ * Format fallback chain for arbitration
+ */
+const FORMAT_FALLBACK = ['yaml', 'json', 'txt', 'md'];
+
+/**
+ * Try format fallback sequence
+ */
+function tryFallback(version) {
+    for (const format of FORMAT_FALLBACK) {
+        try {
+            const brain = loadBrain(version);
+            if (brain) return brain;
+        } catch (e) {
+            console.log(`Fallback: ${format} failed, trying next...`);
+        }
+    }
+    
+    // Return cached if all fail
+    const cached = getCachedBrain();
+    if (cached) {
+        console.log('⚠ Using cached brain (degraded mode)');
+        return cached;
+    }
+    
+    throw new Error('All formats failed, no cache available');
+}
+
+// ============================================================
+// KEEPER LAYER (Security)
+// ============================================================
+
+/**
+ * Compute hash of brain
+ */
+function computeHash(brain) {
+    const content = JSON.stringify(brain, null, 2);
+    return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+/**
+ * Verify brain integrity
+ */
+function keeperVerify(brain) {
+    const result = {
+        valid: true,
+        anomalies: [],
+        checksums: {}
+    };
+    
+    if (!brain) {
+        result.valid = false;
+        result.anomalies.push('No brain to verify');
+        return result;
+    }
+    
+    // Compute checksum
+    result.checksum = computeHash(brain);
+    result.checksums[brain.version] = result.checksum;
+    
+    // Check for unexpected keys
+    const dangerous = ['_eval', '_exec', 'require', 'eval(', 'exec(', 'child_process'];
+    Object.keys(brain).forEach(key => {
+        if (dangerous.some(d => key.toLowerCase().includes(d))) {
+            result.anomalies.push(`Suspicious key: ${key}`);
+        }
+    });
+    
+    if (brain.files) {
+        Object.keys(brain.files).forEach(file => {
+            const content = String(brain.files[file]);
+            dangerous.forEach(d => {
+                if (content.toLowerCase().includes(d)) {
+                    result.anomalies.push(`Suspicious pattern in ${file}: ${d}`);
+                }
+            });
+        });
+    }
+    
+    // Store keeper record
+    const keeperFile = path.join(KEEPERS_DIR, `${brain.version}.json`);
+    fs.writeFileSync(keeperFile, JSON.stringify(result, null, 2));
+    
+    if (result.anomalies.length > 0) {
+        console.warn('⚠ Keeper anomalies detected:');
+        result.anomalies.forEach(a => console.warn('   -', a));
+    } else {
+        console.log('✓ Keeper verification passed');
+    }
+    
+    return result;
+}
+
+/**
+ * Get stored keeper record
+ */
+function getKeeperRecord(version) {
+    const keeperFile = path.join(KEEPERS_DIR, `${version}.json`);
+    if (fs.existsSync(keeperFile)) {
+        try {
+            return JSON.parse(fs.readFileSync(keeperFile, 'utf8'));
+        } catch (e) {
+            return null;
+        }
+    }
+    return null;
+}
+
+// ============================================================
+// DELTA ENGINE
+// ============================================================
+
+/**
+ * Compute delta between two brain versions
+ */
+function computeDelta(fromVersion, toVersion) {
+    const fromBrain = loadBrain(fromVersion);
+    const toBrain = loadBrain(toVersion);
+    
+    const delta = {
+        from: fromVersion,
+        to: toVersion,
+        added: {},
+        modified: {},
+        removed: {},
+        timestamp: new Date().toISOString()
+    };
+    
+    // Find added and modified
+    Object.keys(toBrain.files || {}).forEach(file => {
+        if (!fromBrain.files[file]) {
+            delta.added[file] = toBrain.files[file];
+        } else if (fromBrain.files[file] !== toBrain.files[file]) {
+            delta.modified[file] = {
+                from: fromBrain.files[file],
+                to: toBrain.files[file]
+            };
+        }
+    });
+    
+    // Find removed
+    Object.keys(fromBrain.files || {}).forEach(file => {
+        if (!toBrain.files[file]) {
+            delta.removed[file] = fromBrain.files[file];
+        }
+    });
+    
+    // Check categories
+    const categories = ['learnings', 'memories', 'decisions', 'todos'];
+    categories.forEach(cat => {
+        const fromCat = fromBrain.categories?.[cat] || {};
+        const toCat = toBrain.categories?.[cat] || {};
+        
+        Object.keys(toCat).forEach(key => {
+            if (!fromCat[key]) {
+                delta.added[`${cat}/${key}`] = toCat[key];
+            } else if (fromCat[key] !== toCat[key]) {
+                delta.modified[`${cat}/${key}`] = {
+                    from: fromCat[key],
+                    to: toCat[key]
+                };
+            }
+        });
+        
+        Object.keys(fromCat).forEach(key => {
+            if (!toCat[key]) {
+                delta.removed[`${cat}/${key}`] = fromCat[key];
+            }
+        });
+    });
+    
+    // Save delta
+    const deltaFile = path.join(DELTAS_DIR, `${fromVersion}..${toVersion}.json`);
+    fs.writeFileSync(deltaFile, JSON.stringify(delta, null, 2));
+    console.log('💾 Delta saved:', deltaFile);
+    
+    return delta;
+}
+
+// ============================================================
+// VERSION GRAPH
+// ============================================================
+
+/**
+ * Get version graph
+ */
+function getGraph() {
+    const brains = discoverBrains();
+    const nodes = brains.map(b => ({
+        name: b.name,
+        format: b.format
+    }));
+    
+    // Try to extract lineage from identity files
+    const edges = [];
+    brains.forEach(brain => {
+        try {
+            const brn = loadBrain(brain.name);
+            const parent = brn.identity?.parent || brn.identity?.parent_version;
+            if (parent) {
+                edges.push({ from: parent, to: brain.name });
+            }
+        } catch (e) {}
+    });
+    
+    return { nodes, edges };
+}
+
+/**
+ * Get lineage for a version
+ */
+function getLineage(version) {
+    const lineage = [version];
+    let current = version;
+    
+    while (true) {
+        const brain = loadBrain(current);
+        const parent = brain.identity?.parent || brain.identity?.parent_version;
+        if (!parent) break;
+        lineage.push(parent);
+        current = parent;
+    }
+    
+    return lineage;
+}
+
+// ============================================================
+// MULTI-BRAIN RENDERER
+// ============================================================
+
+/**
+ * Render brain from multiple versions based on needs
+ * @param {object} options - { needs: ['identity', 'memories', 'learnings', 'decisions', 'todos'], priority: [] }
+ */
+function render(options = {}) {
+    const needs = options.needs || ['identity'];
+    const priority = options.priority || [];
+    
+    const result = {
+        identity: null,
+        learnings: {},
+        memories: {},
+        decisions: {},
+        todos: {},
+        sources: {}
+    };
+    
+    // Load in priority order
+    const versions = priority.length > 0 ? priority : discoverBrains().map(b => b.name).reverse();
+    
+    versions.forEach(version => {
+        try {
+            const brain = loadBrain(version);
+            result.sources[version] = true;
+            
+            if (needs.includes('identity') && brain.identity) {
+                result.identity = brain.identity;
+            }
+            
+            if (needs.includes('learnings')) {
+                Object.assign(result.learnings, brain.categories.learnings);
+            }
+            if (needs.includes('memories')) {
+                Object.assign(result.memories, brain.categories.memories);
+            }
+            if (needs.includes('decisions')) {
+                Object.assign(result.decisions, brain.categories.decisions);
+            }
+            if (needs.includes('todos')) {
+                Object.assign(result.todos, brain.categories.todos);
+            }
+        } catch (e) {
+            console.warn(`⚠ Could not load ${version}:`, e.message);
+        }
+    });
+    
+    return result;
+}
+
+// ============================================================
+// CLI
+// ============================================================
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+async function main() {
+    switch (command) {
+        case 'discover':
+        case 'list':
+            console.log('🧠 Brain Engine - Discovered Brains\n');
+            const brains = discoverBrains();
+            brains.forEach((b, i) => {
+                const marker = i === brains.length - 1 ? '👉 ' : '   ';
+                console.log(`${marker}${b.name} (${b.format})`);
+            });
+            console.log(`\nTotal: ${brains.length} brains`);
+            break;
+            
+        case 'load':
+            const version = args[1] || 'latest';
+            console.log('🧠 Brain Engine - Loading\n');
+            const brain = version === 'latest' ? loadLatest() : loadBrain(version);
+            console.log(`Loaded: ${brain.version}`);
+            console.log(`Format: ${brain.format}`);
+            console.log(`Identity: ${brain.identity ? 'yes' : 'no'}`);
+            console.log(`Files: ${Object.keys(brain.files).length}`);
+            console.log(`Categories: learnings(${Object.keys(brain.categories.learnings).length}), memories(${Object.keys(brain.categories.memories).length})`);
+            cacheBrain(brain);
+            break;
+            
+        case 'graph':
+            console.log('🧠 Brain Engine - Version Graph\n');
+            const graph = getGraph();
+            console.log('Nodes:', graph.nodes.map(n => n.name).join(', '));
+            if (graph.edges.length > 0) {
+                console.log('\nEdges:');
+                graph.edges.forEach(e => console.log(`  ${e.from} → ${e.to}`));
+            }
+            break;
+            
+        case 'delta':
+            const from = args[1];
+            const to = args[2];
+            if (!from || !to) {
+                console.log('Usage: node bin/brain-engine.js delta <from-version> <to-version>');
+                process.exit(1);
+            }
+            console.log('🧠 Brain Engine - Delta\n');
+            const delta = computeDelta(from, to);
+            console.log(`From: ${delta.from} → To: ${delta.to}`);
+            console.log(`Added: ${Object.keys(delta.added).length}`);
+            console.log(`Modified: ${Object.keys(delta.modified).length}`);
+            console.log(`Removed: ${Object.keys(delta.removed).length}`);
+            break;
+            
+        case 'render':
+            const needsArg = args.find(a => a.startsWith('--needs='));
+            const needs = needsArg ? needsArg.replace('--needs=', '').split(',') : ['identity'];
+            console.log('🧠 Brain Engine - Render\n');
+            const rendered = render({ needs });
+            console.log(`Needs: ${needs.join(', ')}`);
+            console.log(`Sources: ${Object.keys(rendered.sources).join(', ')}`);
+            console.log(`Identity: ${rendered.identity ? 'loaded' : 'none'}`);
+            console.log(`Learnings: ${Object.keys(rendered.learnings).length}`);
+            console.log(`Memories: ${Object.keys(rendered.memories).length}`);
+            break;
+            
+        case 'keeper-verify':
+        case 'verify':
+            console.log('🧠 Brain Engine - Keeper Verify\n');
+            const toVerify = currentVersion || (args[1] ? loadBrain(args[1]).version : loadLatest().version);
+            const vBrain = currentBrain || loadBrain(toVerify);
+            keeperVerify(vBrain);
+            break;
+            
+        case 'cache-status':
+            console.log('🧠 Brain Engine - Cache Status\n');
+            const failures = getFailures();
+            console.log('Failures recorded:', Object.keys(failures).length);
+            Object.keys(failures).forEach(v => {
+                console.log(`  - ${v}: ${failures[v].error}`);
+            });
+            const cached = getCachedBrain();
+            console.log('\nCached brain:', cached ? cached.version : 'none');
+            break;
+            
+        default:
+            console.log('🧠 Brain Engine - VANT Unified Loader');
+            console.log('');
+            console.log('Usage: node bin/brain-engine.js <command> [options]');
+            console.log('');
+            console.log('Commands:');
+            console.log('  discover, list           List all brain versions');
+            console.log('  load [version]           Load brain (or latest)');
+            console.log('  graph                   Show version relationships');
+            console.log('  delta <from> <to>        Compute diff between versions');
+            console.log('  render --needs=x,y        Compose brain from needs');
+            console.log('  keeper-verify [ver]      Security check brain');
+            console.log('  cache-status           Show cache/failures');
+    }
+}
+
+main().catch(err => {
+    console.error('Error:', err.message);
+    process.exit(1);
+});
+
+module.exports = {
+    discoverBrains,
+    loadBrain,
+    loadLatest,
+    getCurrentBrain,
+    getCurrentVersion,
+    getCachedBrain,
+    cacheBrain,
+    recordFailure,
+    getFailures,
+    tryFallback,
+    keeperVerify,
+    getKeeperRecord,
+    computeDelta,
+    getGraph,
+    getLineage,
+    render,
+    compareVersions,
+    parseBrainFile
+};

--- a/lib/build-test.js
+++ b/lib/build-test.js
@@ -1,0 +1,130 @@
+/**
+ * Vant Build Test
+ * Validates all scripts can load without errors
+ * 
+ * Usage: node bin/build-test.js
+ * 
+ * Exit codes:
+ *   0 - All tests passed
+ *   1 - One or more tests failed
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const TESTS = [];
+
+// Helper to add test
+function test(name, fn) {
+    TESTS.push({ name, fn });
+}
+
+// Test: Config example exists
+test('config.example.ini exists', () => {
+    if (!fs.existsSync('config.example.ini')) {
+        throw new Error('config.example.ini not found');
+    }
+});
+
+// Test: Env example exists
+test('.env.example exists', () => {
+    if (!fs.existsSync('.env.example')) {
+        throw new Error('.env.example not found');
+    }
+});
+
+// Test: Public model exists
+test('public model exists', () => {
+    if (!fs.existsSync('models/public')) {
+        throw new Error('models/public not found');
+    }
+    const identity = path.join('models/public', 'identity.txt');
+    if (!fs.existsSync(identity)) {
+        throw new Error('identity.txt not found in public model');
+    }
+});
+
+// Test: Run.js can start (with timeout)
+test('run.js starts without error', () => {
+    // Check if run.js exists (only in vant-brain, not public)
+    const runPath = path.join(__dirname, '..', 'run.js');
+    if (fs.existsSync(runPath)) {
+        require(runPath);
+    } else {
+        console.log('  (run.js not in public release - skipped)');
+    }
+});
+
+// Test: Health check runs
+test('health.js runs', () => {
+    execSync('node ' + path.join(__dirname, 'health.js'), { stdio: 'pipe' });
+});
+
+// Test: Load.js runs (public model)
+test('load.js runs', () => {
+    execSync('node bin/load.js', { stdio: 'pipe' });
+});
+
+// Test: Rate limiter works
+test('rate-limit.js works', () => {
+    const rl = require('../lib/rate-limit');
+    const status = rl.getStatus();
+    if (!status.remaining || !status.maxPerHour) {
+        throw new Error('Rate limiter broken');
+    }
+    console.log(`  Rate limit: ${status.remaining}/${status.maxPerHour}/hr`);
+});
+
+// Test: Logger can initialize
+test('logger.js works', () => {
+    const logger = require('../lib/logger');
+    logger.info('Test log', { test: true });
+    console.log('  Logger OK');
+});
+
+// Test: Errors can be created
+test('errors.js works', () => {
+    const errors = require('../lib/errors');
+    const err = new errors.VantError('Test error', { code: errors.CODES.CONFIG_MISSING });
+    if (err.code !== 'CONFIG_MISSING') throw new Error('Error code failed');
+    console.log('  Errors OK');
+});
+
+// Note: sync.js, changelog.js, summary.js are only in vant-brain (private)
+
+// Test: Example configs exist (for users to copy)
+test('example configs exist', () => {
+    const examples = ['settings.example.ini', 'mood.example.ini'];
+    examples.forEach(f => {
+        const p = path.join(__dirname, '..', f);
+        if (!fs.existsSync(p)) {
+            throw new Error(`${f} not found`);
+        }
+    });
+});
+
+// Run all tests
+console.log('╔═══════════════════════════════════════╗');
+console.log('║       Vant Build Test v0.8.0         ║');
+console.log('╚═══════════════════════════════════════╝\n');
+
+let passed = 0;
+let failed = 0;
+
+for (const { name, fn } of TESTS) {
+    try {
+        fn();
+        console.log(`✓ ${name}`);
+        passed++;
+    } catch (e) {
+        console.log(`✗ ${name}: ${e.message}`);
+        failed++;
+    }
+}
+
+console.log('\n═══════════════════════════════════════');
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log('═══════════════════════════════════════');
+
+process.exit(failed > 0 ? 1 : 0);

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,17 @@ const path = require('path');
 // Cache
 let _config = null;
 
+// Get VANT version from config.ini - single source of truth
+function getVantVersion() {
+    const configPath = path.join(__dirname, '..', 'config.ini');
+    if (fs.existsSync(configPath)) {
+        const content = fs.readFileSync(configPath, 'utf8');
+        const match = content.match(/VANT_VERSION\s*=\s*(.+)/);
+        if (match) return match[1].trim();
+    }
+    return 'v0.0.0'; // fallback
+}
+
 /**
  * Load config once
  */
@@ -148,5 +159,6 @@ module.exports = {
     getAll,
     getGithub,
     getStegoframe,
+    getVantVersion,
     clearCache
 };

--- a/lib/procedures.js
+++ b/lib/procedures.js
@@ -1,0 +1,422 @@
+/**
+ * Procedures - VANT Brain Operations
+ * 
+ * Gated operations for brain management:
+ * - Merge: Combine brains preserving graphs, deltas, insights, data
+ * - Trim: Delete parts of memory without recursion or full delete
+ * 
+ * Usage:
+ *   const { Merge, Trim } = require('./lib/procedures');
+ *   
+ *   await MergeBrains(from, to, options)
+ *   await TrimBrain(version, scope, options)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const MODELS_DIR = path.join(__dirname, '..', 'models');
+const STATES_DIR = path.join(__dirname, '..', 'states');
+
+/**
+ * GATE - Authorization check for destructive operations
+ */
+function GATE(operation, context = {}) {
+    const GATE_TOKEN = process.env.VANT_GATE_TOKEN || process.env.GITHUB_TOKEN;
+    
+    // Log every gate attempt
+    const logEntry = {
+        operation,
+        timestamp: new Date().toISOString(),
+        context,
+        tokenPresent: !!GATE_TOKEN
+    };
+    
+    const gateLog = path.join(STATES_DIR, 'gate-log.json');
+    try {
+        const logs = fs.existsSync(gateLog) ? JSON.parse(fs.readFileSync(gateLog, 'utf8')) : [];
+        logs.push(logEntry);
+        fs.writeFileSync(gateLog, JSON.stringify(logs.slice(-100), null, 2));
+    } catch (e) {}
+    
+    if (!GATE_TOKEN) {
+        throw new Error(`GATE DENIED: ${operation} requires VANT_GATE_TOKEN or GITHUB_TOKEN`);
+    }
+    
+    return { authorized: true, operation };
+}
+
+/**
+ * Merge - Combine brains without losing data
+ * 
+ * @param {string} fromVersion - Source brain
+ * @param {string} toVersion - Target brain (will be created if not exists)
+ * @param {object} options - { preserve: ['graphs', 'deltas', 'insights', 'data'], dryRun: bool }
+ */
+async function MergeBrains(fromVersion, toVersion, options = {}) {
+    const preserve = options.preserve || ['graphs', 'deltas', 'insights', 'data'];
+    
+    // GATE check
+    GATE('MergeBrains', { from: fromVersion, to: toVersion, preserve });
+    
+    const fromPath = path.join(MODELS_DIR, fromVersion);
+    const toPath = path.join(MODELS_DIR, toVersion);
+    
+    if (!fs.existsSync(fromPath)) {
+        throw new Error(`Source brain not found: ${fromVersion}`);
+    }
+    
+    console.log(`🧬 Merge: ${fromVersion} → ${toVersion}`);
+    console.log(`   Preserve: ${preserve.join(', ')}`);
+    
+    // Create target if needed
+    if (!fs.existsSync(toPath)) {
+        fs.mkdirSync(toPath, { recursive: true });
+        console.log(`   Created: ${toVersion}`);
+    }
+    
+    const result = {
+        from: fromVersion,
+        to: toVersion,
+        added: { files: [], categories: [] },
+        preserved: [],
+        conflicts: [],
+        timestamp: new Date().toISOString()
+    };
+    
+    // 1. Preserve GRAPHS (version lineage)
+    if (preserve.includes('graphs')) {
+        const deltasDir = path.join(STATES_DIR, 'deltas');
+        if (fs.existsSync(deltasDir)) {
+            const deltas = fs.readdirSync(deltasDir).filter(f => f.includes(fromVersion));
+            deltas.forEach(deltaFile => {
+                const src = path.join(deltasDir, deltaFile);
+                const dest = deltaFile.replace(fromVersion, toVersion);
+                fs.copyFileSync(src, path.join(deltasDir, dest));
+                result.preserved.push(`graph: ${deltaFile}`);
+            });
+            console.log(`   📊 Preserved ${deltas.length} graphs/deltas`);
+        }
+    }
+    
+    // 2. Preserve DELTAS
+    if (preserve.includes('deltas')) {
+        const deltasDir = path.join(STATES_DIR, 'deltas');
+        if (fs.existsSync(deltasDir)) {
+            const allDeltas = fs.readdirSync(deltasDir);
+            let copied = 0;
+            allDeltas.forEach(f => {
+                if (f.includes(fromVersion)) {
+                    const dest = f.replace(fromVersion, toVersion);
+                    if (!fs.existsSync(path.join(deltasDir, dest))) {
+                        fs.copyFileSync(path.join(deltasDir, f), path.join(deltasDir, dest));
+                        copied++;
+                    }
+                }
+            });
+            console.log(`   📈 Preserved ${copied} deltas`);
+        }
+    }
+    
+    // 3. Preserve INSIGHTS (learnings)
+    if (preserve.includes('insights')) {
+        const srcLearnings = path.join(fromPath, 'learnings');
+        const destLearnings = path.join(toPath, 'learnings');
+        
+        if (fs.existsSync(srcLearnings) && !fs.existsSync(destLearnings)) {
+            fs.mkdirSync(destLearnings, { recursive: true });
+        }
+        
+        if (fs.existsSync(srcLearnings)) {
+            const files = fs.readdirSync(srcLearnings).filter(f => f.endsWith('.md'));
+            files.forEach(f => {
+                const srcFile = path.join(srcLearnings, f);
+                const destFile = path.join(destLearnings, f);
+                if (!fs.existsSync(destFile)) {
+                    fs.copyFileSync(srcFile, destFile);
+                    result.added.categories.push(`learnings/${f}`);
+                }
+            });
+            console.log(`   💡 Preserved ${files.length} learnings`);
+        }
+    }
+    
+    // 4. Preserve DATA (memories, decisions, todos)
+    if (preserve.includes('data')) {
+        const categories = ['memories', 'decisions', 'todos'];
+        categories.forEach(cat => {
+            const srcCat = path.join(fromPath, cat);
+            const destCat = path.join(toPath, cat);
+            
+            if (fs.existsSync(srcCat) && !fs.existsSync(destCat)) {
+                fs.mkdirSync(destCat, { recursive: true });
+            }
+            
+            if (fs.existsSync(srcCat)) {
+                const files = fs.readdirSync(srcCat).filter(f => f.endsWith('.md'));
+                files.forEach(f => {
+                    const srcFile = path.join(srcCat, f);
+                    const destFile = path.join(destCat, f);
+                    if (!fs.existsSync(destFile)) {
+                        fs.copyFileSync(srcFile, destFile);
+                        result.added.categories.push(`${cat}/${f}`);
+                    }
+                });
+                console.log(`   📦 Preserved ${files.length} ${cat}`);
+            }
+        });
+    }
+    
+    // Copy identity file if target doesn't have one
+    const identityFiles = ['identity.yaml', 'identity.yml', 'identity.json', 'identity.txt'];
+    identityFiles.forEach(f => {
+        const srcId = path.join(fromPath, f);
+        const destId = path.join(toPath, f);
+        if (fs.existsSync(srcId) && !fs.existsSync(destId)) {
+            fs.copyFileSync(srcId, destId);
+            result.added.files.push(f);
+        }
+    });
+    
+    // Log merge
+    const mergeLog = path.join(STATES_DIR, 'merges.json');
+    const logs = fs.existsSync(mergeLog) ? JSON.parse(fs.readFileSync(mergeLog, 'utf8')) : [];
+    logs.push(result);
+    fs.writeFileSync(mergeLog, JSON.stringify(logs.slice(-50), null, 2));
+    
+    console.log(`   ✅ Merge complete: ${result.added.files.length} files, ${result.added.categories.length} categories`);
+    
+    if (options.dryRun) {
+        console.log(`   [DRY RUN - no changes made]`);
+        return { dryRun: true, result };
+    }
+    
+    return result;
+}
+
+/**
+ * Trim - Delete parts of memory (gated, no recursion)
+ * 
+ * @param {string} version - Brain version
+ * @param {string} scope - What to trim: 'category', 'file', 'pattern'
+ * @param {object} options - { target: 'learnings/memory.md', confirm: 'DELETE' }
+ */
+async function TrimBrain(version, scope, options = {}) {
+    const brainPath = path.join(MODELS_DIR, version);
+    
+    if (!fs.existsSync(brainPath)) {
+        throw new Error(`Brain not found: ${version}`);
+    }
+    
+    // GATE check - requires explicit confirmation
+    const confirm = options.confirm || process.env.VANT_TRIM_CONFIRM;
+    if (confirm !== 'DELETE') {
+        throw new Error(`GATE: Trim requires confirm='DELETE' or VANT_TRIM_CONFIRM=DELETE`);
+    }
+    
+    GATE('TrimBrain', { version, scope, target: options.target });
+    
+    console.log(`✂️ Trim: ${version}/${scope}`);
+    
+    const result = {
+        version,
+        scope,
+        target: options.target,
+        deleted: [],
+        timestamp: new Date().toISOString()
+    };
+    
+    if (scope === 'category') {
+        const target = options.target; // e.g., 'learnings'
+        const catPath = path.join(brainPath, target);
+        
+        if (!target || !['learnings', 'memories', 'decisions', 'todos'].includes(target)) {
+            throw new Error(`Invalid category: ${target}. Must be one of: learnings, memories, decisions, todos`);
+        }
+        
+        if (fs.existsSync(catPath)) {
+            const files = fs.readdirSync(catPath).filter(f => f.endsWith('.md'));
+            if (files.length === 0) {
+                console.log(`   Nothing to trim in ${target}`);
+                return { alreadyEmpty: true };
+            }
+            
+            // Move to .trimmed/ instead of full delete
+            const trimmedDir = path.join(MODELS_DIR, '.trimmed', version, target);
+            fs.mkdirSync(trimmedDir, { recursive: true });
+            
+            files.forEach(f => {
+                const src = path.join(catPath, f);
+                const dest = path.join(trimmedDir, f);
+                fs.copyFileSync(src, dest);
+                fs.unlinkSync(src);
+                result.deleted.push(`${target}/${f}`);
+            });
+            
+            fs.rmdirSync(catPath);
+            console.log(`   📤 Moved ${files.length} to .trimmed/${version}/${target}/`);
+        }
+    }
+    else if (scope === 'file') {
+        const target = options.target; // e.g., 'learnings/old.md'
+        if (!target) {
+            throw new Error(`Trim file requires target: 'category/file.md'`);
+        }
+        
+        const filePath = path.join(brainPath, target);
+        if (!fs.existsSync(filePath)) {
+            throw new Error(`File not found: ${target}`);
+        }
+        
+        // Verify no recursion (can't delete parent dirs)
+        const parts = target.split('/');
+        if (parts.length > 2) {
+            throw new Error(`GATE: Cannot trim nested beyond category/file`);
+        }
+        
+        const ext = path.extname(target);
+        if (!['.md', '.txt', '.json', '.yaml', '.yml'].includes(ext)) {
+            throw new Error(`GATE: Refusing to trim non-brain file`);
+        }
+        
+        // Move to .trimmed/
+        const trimmedDir = path.join(MODELS_DIR, '.trimmed', version);
+        fs.mkdirSync(trimmedDir, { recursive: true });
+        
+        const dest = path.join(trimmedDir, path.basename(target));
+        fs.copyFileSync(filePath, dest);
+        fs.unlinkSync(filePath);
+        result.deleted.push(target);
+        
+        console.log(`   📤 Moved ${target} to .trimmed/${version}/`);
+    }
+    else if (scope === 'pattern') {
+        const pattern = options.pattern; // glob pattern
+        if (!pattern) {
+            throw new Error(`Trim pattern requires pattern option`);
+        }
+        
+        if (pattern.includes('..') || pattern.startsWith('/')) {
+            throw new Error(`GATE: Refusing unsafe pattern (no parent dir traversal)`);
+        }
+        
+        const regex = new RegExp(pattern);
+        const categories = ['learnings', 'memories', 'decisions', 'todos'];
+        
+        categories.forEach(cat => {
+            const catPath = path.join(brainPath, cat);
+            if (!fs.existsSync(catPath)) return;
+            
+            const files = fs.readdirSync(catPath).filter(f => f.endsWith('.md') && regex.test(f));
+            files.forEach(f => {
+                const src = path.join(catPath, f);
+                const trimmedDir = path.join(MODELS_DIR, '.trimmed', version, cat);
+                fs.mkdirSync(trimmedDir, { recursive: true });
+                
+                const dest = path.join(trimmedDir, f);
+                fs.copyFileSync(src, dest);
+                fs.unlinkSync(src);
+                result.deleted.push(`${cat}/${f}`);
+            });
+        });
+        
+        console.log(`   📤 Matched ${result.deleted.length} files to pattern: ${pattern}`);
+    }
+    else {
+        throw new Error(`Invalid scope: ${scope}. Use: category, file, pattern`);
+    }
+    
+    // Log trim
+    const trimLog = path.join(STATES_DIR, 'trims.json');
+    const logs = fs.existsSync(trimLog) ? JSON.parse(fs.readFileSync(trimLog, 'utf8')) : [];
+    logs.push(result);
+    fs.writeFileSync(trimLog, JSON.stringify(logs.slice(-50), null, 2));
+    
+    console.log(`   ✅ Trim complete: ${result.deleted.length} items`);
+    
+    return result;
+}
+
+/**
+ * Get version audit - Check version consistency
+ */
+function auditVersions() {
+    const brains = fs.readdirSync(MODELS_DIR).filter(d => {
+        const p = path.join(MODELS_DIR, d);
+        return fs.statSync(p).isDirectory() && !d.startsWith('.');
+    });
+    
+    const report = {
+        totalBrains: brains.length,
+        brains: [],
+        issues: [],
+        timestamp: new Date().toISOString()
+    };
+    
+    brains.forEach(b => {
+        const brain = {
+            name: b,
+            hasIdentity: false,
+            categories: [],
+            files: [],
+            size: 0
+        };
+        
+        const brainPath = path.join(MODELS_DIR, b);
+        
+        // Check root files
+        const rootFiles = fs.readdirSync(brainPath).filter(f => !fs.statSync(path.join(brainPath, f)).isDirectory());
+        rootFiles.forEach(f => {
+            brain.size += fs.statSync(path.join(brainPath, f)).size;
+            if (f.startsWith('identity.')) brain.hasIdentity = true;
+            brain.files.push(f);
+        });
+        
+        // Check categories
+        ['learnings', 'memories', 'decisions', 'todos'].forEach(cat => {
+            const catPath = path.join(brainPath, cat);
+            if (fs.existsSync(catPath)) {
+                brain.categories.push(cat);
+                const files = fs.readdirSync(catPath).filter(f => f.endsWith('.md'));
+                brain.size += files.reduce((s, f) => s + fs.statSync(path.join(catPath, f)).size, 0);
+            }
+        });
+        
+        report.brains.push(brain);
+    });
+    
+    // Check for gaps
+    const versions = report.brains.map(b => b.name).sort((a, b) => {
+        const parse = v => v.replace(/^v/, '').split(/[.-]/).map(n => parseInt(n, 10) || 0);
+        const av = parse(a), bv = parse(b);
+        for (let i = 0; i < Math.max(av.length, bv.length); i++) {
+            if ((av[i] || 0) !== (bv[i] || 0)) return (av[i] || 0) - (bv[i] || 0);
+        }
+        return 0;
+    });
+    
+    // Simple gap check for v0.x versions
+    const v0x = versions.filter(v => v.startsWith('v0.') || v.startsWith('v0'));
+    const numbers = v0x.map(v => {
+        const m = v.match(/v0\.(\d+)/);
+        return m ? parseInt(m[1], 10) : -1;
+    }).filter(n => n >= 0).sort((a, b) => a - b);
+    
+    if (numbers.length > 1) {
+        for (let i = 1; i < numbers.length; i++) {
+            if (numbers[i] !== numbers[i-1] + 1) {
+                report.issues.push(`Gap between v0.${numbers[i-1]} and v0.${numbers[i]}`);
+            }
+        }
+    }
+    
+    return report;
+}
+
+module.exports = {
+    GATE,
+    MergeBrains,
+    TrimBrain,
+    auditVersions
+};


### PR DESCRIPTION
## Summary

Brain Engine v0.6.6 - Multi-format brain loading, versioning, and management for VANT framework.

### New Features

- **Brain Engine** (lib/brain-engine.js): Unified loader supporting txt, json, yaml, markdown formats
  - Smart semver sorting, Arbitration layer, Keeper layer, Delta engine, Version graph

- **Procedures** (lib/procedures.js): Gated brain operations
  - MergeBrains(from, to): Combine brains preserving data
  - TrimBrain(version, scope): Delete parts (gated)
  - auditVersions(): Check for version gaps

- **CLI**: bin/brain-engine.js and bin/procedures.js

### Fixes

- Version single source of truth: config now the source for VANT version

### Notes

- Private brain data NOT included (models/*, states/*) - those stay in vant-brain private repo
- This is the OSS framework portion - the VANT intelligence lives in vant-brain

Co-authored-by: openhands <openhands@all-hands.dev>