### PR TITLE
Add nav_order for section sorting

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -36,3 +36,12 @@ nav_sections:
   guides: "Guides"
   community: "Community"
   legal: "Legal"
+
+# Section order (numeric - lower shows first)
+nav_order:
+  getting-started: 1
+  tutorials: 2
+  guides: 3
+  reference: 4
+  community: 5
+  legal: 6

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,3 +27,12 @@ defaults:
       type: pages
     values:
       layout: default
+
+# Custom section titles for navigation (folder => display title)
+nav_sections:
+  getting-started: "Getting Started"
+  tutorials: "Tutorials"
+  reference: "Reference"
+  guides: "Guides"
+  community: "Community"
+  legal: "Legal"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -620,85 +620,20 @@
     
     <!-- Sidebar navigation -->
     <aside class="sidebar" id="sidebar">
-        <!-- Getting Started -->
-        <div class="sidebar-section">
-            <div class="sidebar-title">Getting Started</div>
-            <ul class="sidebar-nav">
-                <li><a href="/vant/getting-started/install.html">Installation</a></li>
-                
-                <li><a href="/vant/getting-started/quick-start.html">Quick Start</a></li>
-            </ul>
-        </div>
-        
-        <!-- Tutorials -->
-        <div class="sidebar-section">
-            <div class="sidebar-title">Tutorials</div>
-            <ul class="sidebar-nav">
-                <li><a href="/vant/tutorials/build-agent.html">Build First Agent</a></li>
-                <li><a href="/vant/tutorials/multi-agent.html">Multi-Agent System</a></li>
-                <li><a href="/vant/tutorials/telegram-bot.html">Telegram Bot</a></li>
-            </ul>
-        </div>
-        
-        <!-- Reference -->
-        <div class="sidebar-section">
-            <div class="sidebar-title">Reference</div>
-            <ul class="sidebar-nav">
-                <li><a href="/vant/reference/cli.html">CLI Reference</a></li>
-                <li><a href="/vant/reference/configuration.html">Configuration</a></li>
-                <li><a href="/vant/reference/api.html">Module API</a></li>
-                <li><a href="/vant/reference/schema.html">Brain Schema</a></li>
-                <li><a href="/vant/reference/errors.html">Error Codes</a></li>
-                <li><a href="/vant/reference/entropy.html">Entropy-Patch</a></li>
-            </ul>
-        </div>
-        
-        <!-- Guides -->
-        <div class="sidebar-section">
-            <div class="sidebar-title">Guides</div>
-            <ul class="sidebar-nav">
-                <li><a href="/vant/guides/architecture.html">Architecture</a></li>
-                <li><a href="/vant/guides/brain.html">Brain Structure</a></li>
-                
-                
-                <li><a href="/vant/guides/onboard.html">Onboarding</a></li>
-                <li><a href="/vant/guides/succession.html">Succession</a></li>
-                <li><a href="/vant/guides/resolution.html">Resolution</a></li>
-                <li><a href="/vant/guides/security.html">Security</a></li>
-                <li><a href="/vant/guides/multi-agent.html">Multi-Agent</a></li>
-                <li><a href="/vant/guides/mcp.html">MCP Server</a></li>
-                <li><a href="/vant/guides/docker.html">Docker</a></li>
-                <li><a href="/vant/guides/plugins.html">Plugins</a></li>
-                <li><a href="/vant/guides/steganography.html">Steganography</a></li>
-                <li><a href="/vant/guides/github.html">GitHub</a></li>
-                <li><a href="/vant/guides/release.html">Release</a></li>
-                <li><a href="/vant/guides/style.html">Style</a></li>
-                <li><a href="/vant/guides/operations.html">Operations</a></li>
-                <li><a href="/vant/guides/testing.html">Testing</a></li>
-                <li><a href="/vant/guides/audit.html">Audit</a></li>
-                <li><a href="/vant/guides/troubleshooting.html">Troubleshooting</a></li>
-            </ul>
-        </div>
-        
-        <!-- Community -->
-        <div class="sidebar-section">
-            <div class="sidebar-title">Community</div>
-            <ul class="sidebar-nav">
-                <li><a href="/vant/examples.html">Examples</a></li>
-                <li><a href="/vant/faq.html">FAQ</a></li>
-                <li><a href="/vant/contributing.html">Contributing</a></li>
-            </ul>
-        </div>
-        
-        <!-- Legal -->
-        <div class="sidebar-section">
-            <div class="sidebar-title">Legal</div>
-            <ul class="sidebar-nav">
-                <li><a href="/vant/legal/index.html">Terms & Disclaimer</a></li>
-                <li><a href="/vant/legal/privacy.html">Privacy Policy</a></li>
-                <li><a href="/vant/legal/environment.html">Environment & Limits</a></li>
-            </ul>
-        </div>
+        {% if site.nav %}
+          {% for section in site.nav %}
+            {% if section.items %}
+            <div class="sidebar-section">
+                <div class="sidebar-title">{{ section.title }}</div>
+                <ul class="sidebar-nav">
+                {% for item in section.items %}
+                    <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
+                {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
     </aside>
     
     <!-- Main content -->

--- a/docs/_plugins/nav_generator.rb
+++ b/docs/_plugins/nav_generator.rb
@@ -1,0 +1,59 @@
+# Dynamic navigation generator - builds nav from docs folder structure
+# Folders become collapsible sections, files become links
+# Supports custom section titles from nav_sections config
+require 'fileutils'
+
+module Jekyll
+  class NavGenerator < Generator
+    safe true
+
+    def generate(site)
+      @site = site
+      nav_data = build_nav(site.pages, site.config)
+      site.config['nav'] = nav_data
+    end
+
+    def build_nav(pages, config)
+      nav = []
+      docs_dir = config['source'] || 'docs'
+      section_titles = config['nav_sections'] || {}
+
+      # Get all docs folders
+      folders = {}
+      pages.each do |page|
+        next unless page.path
+        path = page.path
+
+        # Skip special files
+        next if path.start_with?('_') || path.start_with?('lib/')
+
+        # Get folder
+        folder = File.dirname(path)
+        folder = '.' if folder == '.'
+
+        # Get title from frontmatter or filename
+        title = page.data['title'] || File.basename(path, '.md').gsub('-', ' ').capitalize
+        title = title.to_s
+
+        # Skip index and hidden pages
+        next if page.data['nav'] == false
+        next if File.basename(path) == 'index.md'
+
+        if folder == '.'
+          nav << { 'title' => title, 'url' => page.url }
+        else
+          # Use custom section title if defined, otherwise capitalize folder name
+          section_title = section_titles[folder] || folder.gsub('-', ' ').capitalize
+          folders[folder] ||= { 'title' => section_title, 'items' => [] }
+          folders[folder]['items'] << { 'title' => title, 'url' => page.url }
+        end
+      end
+
+      # Sort folders
+      folders.each { |k, v| v['items'].sort_by! { |i| i['title'] } }
+
+      # Merge root items and folders
+      nav + folders.values.sort_by { |f| f['title'] }
+    end
+  end
+end

--- a/docs/_plugins/nav_generator.rb
+++ b/docs/_plugins/nav_generator.rb
@@ -17,6 +17,14 @@ module Jekyll
       nav = []
       docs_dir = config['source'] || 'docs'
       section_titles = config['nav_sections'] || {}
+      
+      # Map root-level files to sections
+      root_section_map = {
+        'examples.md' => 'community',
+        'faq.md' => 'community', 
+        'contributing.md' => 'community',
+        'legal.md' => 'legal'
+      }
 
       # Get all docs folders
       folders = {}
@@ -29,15 +37,23 @@ module Jekyll
 
         # Get folder
         folder = File.dirname(path)
+        filename = File.basename(path, '.md')
+        
+        # Map root-level docs to sections
+        if folder == '.'
+          mapped = root_section_map[filename + '.md']
+          folder = mapped if mapped
+        end
+        
         folder = '.' if folder == '.'
 
         # Get title from frontmatter or filename
-        title = page.data['title'] || File.basename(path, '.md').gsub('-', ' ').capitalize
+        title = page.data['title'] || filename.gsub('-', ' ').capitalize
         title = title.to_s
 
         # Skip index and hidden pages
         next if page.data['nav'] == false
-        next if File.basename(path) == 'index.md'
+        next if filename == 'index.md'
 
         if folder == '.'
           nav << { 'title' => title, 'url' => page.url }
@@ -52,7 +68,7 @@ module Jekyll
       # Sort folders
       folders.each { |k, v| v['items'].sort_by! { |i| i['title'] } }
 
-      # Merge root items and folders
+      # Merge root items and folders - ensure section order
       nav + folders.values.sort_by { |f| f['title'] }
     end
   end

--- a/docs/_plugins/nav_generator.rb
+++ b/docs/_plugins/nav_generator.rb
@@ -1,6 +1,5 @@
 # Dynamic navigation generator - builds nav from docs folder structure
-# Folders become collapsible sections, files become links
-# Auto-crawls docs root and groups loose files
+# Folders become collapsible sections, MD files become links
 require 'fileutils'
 
 module Jekyll
@@ -14,77 +13,53 @@ module Jekyll
     end
 
     def build_nav(pages, config)
-      nav = []
-      docs_dir = config['source'] || 'docs'
       section_titles = config['nav_sections'] || {}
-      
-      # Auto-detect root-level docs and group them
       root_docs = []
-
-      # Get all docs folders
       folders = {}
+
       pages.each do |page|
         next unless page.path
         path = page.path
 
-        # Skip special files and folders that match sections
+        # Skip special folders/files
         next if path.start_with?('_') || path.start_with?('lib/')
         next if path == 'CHANGELOG.md' || path == 'LICENSE' || path == 'README.md'
 
-        # Get folder and filename
         folder = File.dirname(path)
         filename = File.basename(path, '.md')
-        
-        # Get title from frontmatter or filename
-        title = page.data['title'] || filename.gsub('-', ' ').capitalize
-        title = title.to_s
         
         # Skip index and hidden pages  
         next if page.data['nav'] == false
         next if filename == 'index.md'
         
-        # Handle root-level docs - auto-group by filename
-        if folder == '.' || folder == ''
-          # Skip root docs that have matching section folders (they'd be duplicates)
-          section_folders = section_titles.keys + ['community', 'legal', 'guides', 'reference', 'tutorials', 'getting-started']
-          if section_folders.include?(filename)
-            next  # Skip - user should use folder version
-          end
-          
-          # Known groupings for root docs
-          if ['examples', 'faq', 'contributing'].include?(filename)
-            folder = 'community'
-          elsif filename == 'legal'
-            folder = 'legal'
-          else
-            # Other root docs go to "Docs" section
-            root_docs << { 'title' => title, 'url' => page.url }
-            next
-          end
-        end
+        # Title from frontmatter or filename
+        title = page.data['title'] || filename.gsub('-', ' ').capitalize
+        title = title.to_s
         
-        folder = '.' if folder == '.'
-
-        if folder == '.'
-          nav << { 'title' => title, 'url' => page.url }
+        if folder == '.' || folder == ''
+          # Root-level doc - add to root list
+          root_docs << { 'title' => title, 'url' => page.url }
         else
-          # Use custom section title if defined, otherwise capitalize
+          # Folder name = section, file = link
           section_title = section_titles[folder] || folder.gsub('-', ' ').capitalize
           folders[folder] ||= { 'title' => section_title, 'items' => [] }
           folders[folder]['items'] << { 'title' => title, 'url' => page.url }
         end
       end
 
-      # Sort folders by title
+      # Sort items in each folder
       folders.each { |k, v| v['items'].sort_by! { |i| i['title'] } }
 
-      # Build result: root links first, then folders sorted by title
-      result = nav + folders.values.sort_by { |f| f['title'] }
+      # Build result: root docs first, then folders sorted by title
+      result = []
       
-      # Add ungrouped root docs as "Docs" section at end
+      # Add root docs as "Docs" section
       if root_docs.any?
         result << { 'title' => 'Docs', 'items' => root_docs.sort_by { |i| i['title'] } }
       end
+      
+      # Add folders as sections
+      result += folders.values.sort_by { |f| f['title'] }
       
       result
     end

--- a/docs/_plugins/nav_generator.rb
+++ b/docs/_plugins/nav_generator.rb
@@ -1,6 +1,6 @@
 # Dynamic navigation generator - builds nav from docs folder structure
 # Folders become collapsible sections, files become links
-# Supports custom section titles from nav_sections config
+# Auto-crawls docs root and groups loose files
 require 'fileutils'
 
 module Jekyll
@@ -18,13 +18,8 @@ module Jekyll
       docs_dir = config['source'] || 'docs'
       section_titles = config['nav_sections'] || {}
       
-      # Map root-level files to sections
-      root_section_map = {
-        'examples.md' => 'community',
-        'faq.md' => 'community', 
-        'contributing.md' => 'community',
-        'legal.md' => 'legal'
-      }
+      # Auto-detect root-level docs and group them
+      root_docs = []
 
       # Get all docs folders
       folders = {}
@@ -32,44 +27,66 @@ module Jekyll
         next unless page.path
         path = page.path
 
-        # Skip special files
+        # Skip special files and folders that match sections
         next if path.start_with?('_') || path.start_with?('lib/')
+        next if path == 'CHANGELOG.md' || path == 'LICENSE' || path == 'README.md'
 
-        # Get folder
+        # Get folder and filename
         folder = File.dirname(path)
         filename = File.basename(path, '.md')
         
-        # Map root-level docs to sections
-        if folder == '.'
-          mapped = root_section_map[filename + '.md']
-          folder = mapped if mapped
+        # Get title from frontmatter or filename
+        title = page.data['title'] || filename.gsub('-', ' ').capitalize
+        title = title.to_s
+        
+        # Skip index and hidden pages  
+        next if page.data['nav'] == false
+        next if filename == 'index.md'
+        
+        # Handle root-level docs - auto-group by filename
+        if folder == '.' || folder == ''
+          # Skip root docs that have matching section folders (they'd be duplicates)
+          section_folders = section_titles.keys + ['community', 'legal', 'guides', 'reference', 'tutorials', 'getting-started']
+          if section_folders.include?(filename)
+            next  # Skip - user should use folder version
+          end
+          
+          # Known groupings for root docs
+          if ['examples', 'faq', 'contributing'].include?(filename)
+            folder = 'community'
+          elsif filename == 'legal'
+            folder = 'legal'
+          else
+            # Other root docs go to "Docs" section
+            root_docs << { 'title' => title, 'url' => page.url }
+            next
+          end
         end
         
         folder = '.' if folder == '.'
 
-        # Get title from frontmatter or filename
-        title = page.data['title'] || filename.gsub('-', ' ').capitalize
-        title = title.to_s
-
-        # Skip index and hidden pages
-        next if page.data['nav'] == false
-        next if filename == 'index.md'
-
         if folder == '.'
           nav << { 'title' => title, 'url' => page.url }
         else
-          # Use custom section title if defined, otherwise capitalize folder name
+          # Use custom section title if defined, otherwise capitalize
           section_title = section_titles[folder] || folder.gsub('-', ' ').capitalize
           folders[folder] ||= { 'title' => section_title, 'items' => [] }
           folders[folder]['items'] << { 'title' => title, 'url' => page.url }
         end
       end
 
-      # Sort folders
+      # Sort folders by title
       folders.each { |k, v| v['items'].sort_by! { |i| i['title'] } }
 
-      # Merge root items and folders - ensure section order
-      nav + folders.values.sort_by { |f| f['title'] }
+      # Build result: root links first, then folders sorted by title
+      result = nav + folders.values.sort_by { |f| f['title'] }
+      
+      # Add ungrouped root docs as "Docs" section at end
+      if root_docs.any?
+        result << { 'title' => 'Docs', 'items' => root_docs.sort_by { |i| i['title'] } }
+      end
+      
+      result
     end
   end
 end

--- a/docs/_plugins/nav_generator.rb
+++ b/docs/_plugins/nav_generator.rb
@@ -14,6 +14,7 @@ module Jekyll
 
     def build_nav(pages, config)
       section_titles = config['nav_sections'] || {}
+      section_order = config['nav_order'] || {}
       root_docs = []
       folders = {}
 
@@ -47,10 +48,10 @@ module Jekyll
         end
       end
 
-      # Sort items in each folder
+      # Sort: items by title, folders by nav_order
       folders.each { |k, v| v['items'].sort_by! { |i| i['title'] } }
 
-      # Build result: root docs first, then folders sorted by title
+      # Build result: root docs first, then folders by nav_order
       result = []
       
       # Add root docs as "Docs" section
@@ -58,8 +59,13 @@ module Jekyll
         result << { 'title' => 'Docs', 'items' => root_docs.sort_by { |i| i['title'] } }
       end
       
-      # Add folders as sections
-      result += folders.values.sort_by { |f| f['title'] }
+      # Add folders sorted by nav_order (find folder key from title)
+      result += folders.values.sort_by do |f|
+        title = f['title']
+        # Find folder name with this title
+        folder_key = section_titles.key(title) || title.downcase
+        section_order[folder_key] || 999
+      end
       
       result
     end


### PR DESCRIPTION
Add nav_order config for section ordering.

## Changes
- Add `nav_order` config in _config.yml (numeric - lower shows first)
- Update nav_generator.rb to sort by nav_order instead of alphabetically
- Docs section (root MDs) always first, then folders by order

@dhaupin can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3cf9b8fc-85ee-427b-aac9-a93ffc75dbbb)