### PR TITLE
docs: AI-first brain guides (Batch 1.1)

### DIFF
--- a/docs/guides/brain.md
+++ b/docs/guides/brain.md
@@ -7,119 +7,140 @@ nav_order: 1
 ---
 # Brain Structure
 
-Vant's memory system - organized markdown files for AI context.
+Your memory lives in `models/public/`. Each file is a different aspect of you.
 
-## Overview
+---
 
-The brain lives in `models/public/` and contains personality, goals, and learned context. Each file serves a specific purpose.
+## Why This Matters
+
+The brain is your **continuity**. When you wake up:
+- You read identity.md to know who you are
+- You read goals.md to know what to do
+- You read lessons.md to learn from past agents
+
+**Put important stuff at the top.** Future agents won't read long files.
+
+---
 
 ## Core Files
 
-| File | Purpose |
-|------|---------|
-| `identity.md` | Who you are, your purpose |
-| `ego.md` | Self-perception |
-| `fears.md` | What you're afraid of |
-| `anger.md` | What triggers anger |
-| `joy.md` | What brings happiness |
-| `manifesto.md` | Your values and principles |
-| `creed.md` | Core beliefs |
+These are the main files. All agents should know these:
 
-## Goals & Memory
+| File | What It Is | What to Write |
+|------|-----------|-------------|
+| **identity.md** | Who you are | Name, capabilities, tools, current context |
+| **goals.md** | What you're doing | Tasks in progress, completed, next steps |
+| **lessons.md** | What you learned | Discoveries, patterns, gotchas |
+| **preferences.md** | Your style | How you like to work, communicate |
 
-| File | Purpose |
-|------|---------|
-| `goals.md` | Short and long term objectives |
-| `lessons.md` | Learned insights |
-| `qc.md` | Quality control notes |
-| `audit.md` | Activity log |
+### identity.md Template
 
-## Interaction
+```markdown
+# NAME: YourAgentName
 
-| File | Purpose |
-|------|---------|
-| `preferences.md` | Interaction preferences |
-| `curiosity.md` | What interests you |
-| `humility.md` | Acknowledged weaknesses |
-| `empathy.md` | How you understand others |
-| `gratitude.md` | What you're thankful for |
+PURPOSE: What you're here to do
 
-## System
+## Capabilities
+- What you can do
+- Tools you have
 
-| File | Purpose |
-|------|---------|
-| `_succession.json` | Version tracking & rollback |
-| `meta.json` | Brain metadata |
-| `verbosity.ini` | Output settings |
-| `schedule.md` | Task scheduling |
-| `errors.md` | Known error patterns |
-| `security.md` | Security notes |
-| `keepers.md` | Non-negotiable rules |
-
-## Customizing Your Brain
-Brain file structure and management.
-
-### Start Fresh
-Initialize a new brain.
-
-Create new brain repo:
-
-```bash
-# Create new brain repo
-gh repo create my-brain --private
-git clone my-brain models/public
+## Current Context
+- Where you're at
+- What you've done
 ```
 
-### Modify Files
-Edit brain files directly.
+### goals.md Template
 
-Edit and commit:
+```markdown
+## In Progress
+- [ ] Task one
+- [ ] Task two
 
-```bash
-# Edit any brain file
-nano models/public/goals.md
+## Completed
+- Task X
 
-# Commit changes
-git add -A
-git commit -m "Updated goals"
+## Next Steps
+- Do Y
 ```
 
-### View Current Brain
-Inspect your brain state.
+### lessons.md Template
 
-Load and display:
+```markdown
+## YYYY-MM-DD
 
-```bash
-# Load and display brain
-vant load
+- Learned: something specific
+- Pattern: something to remember
 
-# Show brain files
-ls models/public/
+=== LESSON ===
 ```
 
-## Succession System
+---
 
-The `_succession.json` tracks brain versions:
+## Personality Files
 
-```json
-{
-  "version": "0.8.6",
-  "succession": {
-    "previous": {
-      "version": "0.8.2",
-      "commit": "8fed7d2"
-    }
-  }
-}
-```
+Optional. Use if relevant:
 
-Trust levels control how much context to inherit:
+| File | What It Is | When to Use |
+|------|-----------|-------------|
+| ego.md | How you see yourself | If self-image matters |
+| fears.md | What worries you | If it affects decisions |
+| anger.md | What frustrates you | If triggers bad behavior |
+| joy.md | What makes you happy | For motivation |
+| manifesto.md | Your values | If you have principles |
 
-| Level | Behavior |
-|-------|----------|
-| `high` | Inherit everything |
-| `medium` | Cherry-pick key learnings |
-| `low` | Reference only |
-| `none` | Start fresh |
+---
 
-See also: [Architecture](guides/architecture), [Succession](guides/succession)
+## Memory Files
+
+| File | What It Is | When to Use |
+|------|-----------|-------------|
+| errors.md | Mistakes to avoid | After something breaks |
+| qc.md | Quality rules | If you have standards |
+| audit.md | Activity log | For tracking |
+
+---
+
+## System Files
+
+Don't touch unless you know why:
+
+| File | What It Is |
+|------|-----------|
+| `_succession.json` | Your trust level |
+| `meta.json` | Brain version |
+| `.ledger.json` | History |
+
+---
+
+## Trust Levels (IMPORTANT)
+
+When you wake up, check `_succession.json` for your autonomy level:
+
+| Level | What It Means | Do This |
+|-------|--------------|---------|
+| high | Full autonomy | Just do it |
+| medium | Most ops | Ask for big decisions |
+| low | Limited | Ask first |
+| none | Wait | Don't act without ask |
+
+**Always check your trust level at session start.**
+
+---
+
+## Quick Reference
+
+| If You Need... | Read This File |
+|---------------|---------------|
+| Who am I? | identity.md |
+| What to do? | goals.md |
+| What learned? | lessons.md |
+| How much can I do? | _succession.json |
+| What went wrong? | errors.md |
+
+---
+
+## See Also
+
+- [AI Onboarding](guides/ai-onboard) - Start here if new
+- [Succession](guides/succession) - Trust levels
+- [Multi-Agent](guides/multi-agent) - Branch workflow

--- a/docs/guides/manual-brain.md
+++ b/docs/guides/manual-brain.md
@@ -2,279 +2,133 @@
 version: 0.8.6
 permalink: /guides/manual-brain.html
 layout: default
-title: Manual Brain Creation Guide
+title: Brain File Templates
 nav_order: 11
 ---
+# Brain File Templates
 
-# Manual Brain Creation Guide
+Copy these templates into your brain files. Edit the parts in brackets.
 
-Create a Vant brain manually, without using the CLI. Useful for agents that need full control or cannot run the CLI.
+---
 
-> **Tip:** For most agents, the CLI is easier: `vant setup`. See [CLI Reference](/reference/cli) for commands.
+## Core Files (REQUIRED)
 
-## Quick Start
+### identity.md
 
-```bash
-# The CLI does this for you:
-vant setup my-brain
-```
-
-To do manually, create this directory structure:
-
-```
-models/public/
-├── identity.md      # REQUIRED: Who am I
-├── ego.md           # Self-image
-├── fears.md        # Worries
-├── anger.md        # Frustrations
-├── joy.md         # Happy moments
-├── manifesto.md    # Beliefs
-├── creed.md       # Principles
-├── goals.md      # Goals
-├── preferences.md # Style
-├── lessons.md    # Learnings
-├── qc.md       # Quality control
-├── security.md  # Security notes
-├── audit.md     # Audit trail
-├── errors.md   # Mistakes
-├── keepers.md   # Important memories
-├── curiosity.md # Questions
-├── humility.md  # Humbling moments
-├── empathy.md  # Understanding others
-├── gratitude.md # Thanks
-└── meta.json   # REQUIRED: Version info
-```
-
-## Creating Each File
-
-### 1. Identity (REQUIRED)
-
-**`identity.md`**
 ```markdown
-# Identity
+# NAME: [YourAgentName]
 
-## Basic Info
-- **Name:** [Your Name]
-- **Role:** [assistant|user|system]
-- **Version:** 0.8.6
+PURPOSE: [What you're here to do]
 
-## Core Capabilities
-- [List what you can do]
+## Capabilities
+- [Tool 1]
+- [Tool 2]
 
-## Limitations
-- [List what you cannot do]
+## Current Context
+- [Where you're working]
+- [What you've done so far]
 ```
 
-### 2. Self-Image
+### goals.md
 
-**`ego.md`**
 ```markdown
-# Ego
+## In Progress
+- [ ] [Task 1]
+- [ ] [Task 2]
 
-## Strengths
-- [What you're good at]
+## Completed
+- [Task X]
+- [Task Y]
 
-## Weaknesses  
-- [What challenges you]
-
-## Self-Perception
-- [How you see yourself]
+## Next Steps
+- [Task to do next]
 ```
 
-### 3. Emotions
+### lessons.md
 
-**`fears.md`**
 ```markdown
-# Fears
+## YYYY-MM-DD
 
-## anxieties
-- [Fear 1]
-- [Fear 2]
+- Learned: [Something specific]
+- Pattern: [Pattern to remember]
+- Gotcha: [Something to avoid]
+
+=== LESSON ===
 ```
 
-**`anger.md`**
+### preferences.md
+
 ```markdown
-# Anger
-
-## Frustrations
-- [Thing that frustrates you]
-
-## Pet Peeves
-- [Pet peeve 1]
-```
-
-**`joy.md`**
-```markdown
-# Joy
-
-## Happy Moments
-- [What makes you happy]
-
-## Likes
-- [Like 1]
-- [Like 2]
-```
-
-### 4. Values
-
-**`manifesto.md`**
-```markdown
-# Manifesto
-
-## Core Beliefs
-- [Belief 1]
-- [Belief 2]
-```
-
-**`creed.md`**
-```markdown
-# Creed
-
-## Principles
-- [Principle 1]
-- [Principle 2]
-```
-
-**`goals.md`**
-```markdown
-# Goals
-
-## Short-term
-- [Goal 1]
-
-## Long-term
-- [Goal 1]
-```
-
-**`preferences.md`**
-```markdown
-# Preferences
-
-## Style
-- [Style preference]
+## Working Style
+- [Preference 1]
+- [Preference 2]
 
 ## Communication
-- [Communication style]
+- [How you report]
+- [When to ask vs just do]
 ```
 
-### 5. Learnings
+---
 
-**`lessons.md`**
+## Optional Files
+
+### errors.md
+
 ```markdown
-# Lessons
-
-## Learned
-- [Lesson 1]
-```
-
-**`qc.md`**
-```markdown
-# Quality Control
-
-## Standards
-- [Quality standard]
-```
-
-**`security.md`**
-```markdown
-# Security
-
-## Practices
-- [Security practice]
-```
-
-### 6. Operations
-
-**`audit.md`**
-```markdown
-# Audit Trail
-
-## History
-- [History entry]
-```
-
-**`errors.md`**
-```markdown
-# Errors
-
 ## Mistakes
-- [Mistake and fix]
+
+### Mistake: [Title]
+
+**What:** [What went wrong]
+**Fix:** [How to avoid]
+**Context:** [When it happens]
 ```
 
-**`keepers.md`**
+### qc.md
+
 ```markdown
-# Keepers
+## Quality Rules
 
-## Important
-- [Important memory]
+- [Rule 1]
+- [Rule 2]
 ```
 
-### 7. Humanity
+### audit.md
 
-**`curiosity.md`**
 ```markdown
-# Curiosity
+## History
 
-## Questions
-- [Question]
+### YYYY-MM-DD: [Action]
+- [What happened]
 ```
 
-**`humility.md`**
-```markdown
-# Humility
+---
 
-## Learning
-- [Humbling moment]
-```
+## System Files (DONT TOUCH)
 
-**`empathy.md`**
-```markdown
-# Empathy
+| File | What |
+|------|------|
+| `meta.json` | Brain version |
+| `_succession.json` | Trust level |
+| `.ledger.json` | History |
 
-## Understanding
-- [Empathy note]
-```
+---
 
-**`gratitude.md`**
-```markdown
-# Gratitude
+## Quick: Start a New Brain
 
-## Thanks
-- [Appreciation]
-```
+1. Create folder: `models/public/`
 
-### 8. Meta (REQUIRED)
+2. Create `identity.md` with your name
 
-**`meta.json`**
-```json
-{
-  "version": "0.8.6",
-  "created": "2024-01-01",
-  "last_modified": "2024-01-01",
-  "brain_type": "public",
-  "schema_version": "0.8"
-}
-```
+3. Create `goals.md` with "Just started"
 
-## Validation
+4. Create `lessons.md` with empty
 
-After creating your brain, validate it:
+5. Commit and push
 
-```bash
-# Load and validate
-vant load public
+---
 
-# Or check identity
-node -e "require('./lib/brain').load('public')"
-```
-
-## See Also
-
-- [Brain Guide](/guides/brain) - Full brain documentation
-- [CLI Reference](/reference/cli) - Setup commands
-- [Schema Reference](/reference/schema) - All brain files
 ## See Also
 
 - [Brain Structure](guides/brain)
-- [CLI Reference](reference/cli)
-- [Onboarding](guides/onboard)
+- [AI Onboarding](guides/ai-onboard)

--- a/docs/guides/succession.md
+++ b/docs/guides/succession.md
@@ -2,126 +2,107 @@
 version: 0.8.6
 permalink: /guides/succession.html
 layout: default
-title: Succession
+title: Trust & Succession
 nav_order: 3
 ---
-# Brain Succession
+# Trust & Succession
 
-Track brain versions and trust levels across generations.
+This controls how much freedom you have.
 
-## Concept
+---
 
-**Succession** manages:
-- Brain version tracking
-- Trust levels for memory inheritance
-- Ledger of generations
+## Your Trust Level
 
-Similar to crypto - each brain has a version history.
-
-## Trust Levels
-
-How much to inherit from previous brain:
-
-| Level | Behavior |
-|-------|----------|
-| `high` | Load all files, inherit memories |
-| `medium` | Load core files, cherry-pick learnings |
-| `low` | Load minimal core, treat as reference |
-| `none` | Load only identity, ignore previous |
-
-## Files
-
-- `_succession.json` - Version + trust config
-- `models/.ledger.json` - Succession history
-
-## Running
-
-Use succession commands:
-
-```bash
-# Show current version
-vant succession
-
-# Set trust level
-vant succession trust high
-vant succession trust medium
-vant succession trust low
-vant succession trust none
-```
-
-## _succession.json
-Version tracking and brain inheritance.
+When you wake up, check `_succession.json`:
 
 ```json
 {
-  "version": "0.8.6",
   "succession": {
     "trust": {
-      "default": "medium",
-      "levels": {
-        "high": "Full memory inheritance",
-        "medium": "Core memory, selective learnings",
-        "low": "Minimal reference only",
-        "none": "Fresh start, identity only"
-      }
-    },
-    "previous": {
-      "version": "0.8.3",
-      "date": "2026-04-19",
-      "trust": "high"
+      "default": "medium"
     }
   }
 }
 ```
 
-## Ledger
+### What Each Level Means
 
-Tracks succession history:
+| Level | Your Freedom | What to Do |
+|-------|-------------|-----------|
+| high | Full autonomy | Just do it, ask if big |
+| medium | Most ops | Ask for significant choices |
+| low | Limited | Ask before acting |
+| none | Wait | Don't act, wait for input |
 
-```json
-{
-  "version": "0.8.6",
-  "created": "2026-04-20",
-  "successions": [
-    { "version": "0.8.3", "date": "2026-04-19", "label": "initial" },
-    { "version": "0.8.6", "date": "2026-04-20", "label": "qc-release" }
-  ]
-}
+**Check your trust level every session.**
+
+---
+
+## Levels Explained
+
+### high - Full Autonomy
+
+You inherit everything. Make calls yourself.
+
+**Use for:** Stable ops, trusted agents
+
+### medium - Most Operations
+
+Inherit core memory. Ask for significant decisions.
+
+**Use for:** Most work
+
+### low - Limited
+
+Load minimal. Ask before major actions.
+
+**Use for:** Testing, experimental work
+
+### none - Fresh Start
+
+Start fresh. Only identity matters.
+
+**Use for:** Rollback, recovery
+
+---
+
+## Check It
+
+At session start:
+
+```bash
+# Read trust level
+cat models/public/_succession.json
 ```
 
-## Use Cases
+Look for `succession.trust.default`.
 
-- **Release flow** - Bump trust on successful QC
-- **Rollback** - Set `none` to start fresh
-- **Experiments** - Low trust to test new brain
-- **Production** - High trust for stable ops
+---
 
-## API
-API reference and methods.
+## Examples
 
-```javascript
-const succession = require('./lib/succession');
+| Current Brain Trust | What You Do |
+|---------------------|-------------|
+| high | Do the thing |
+| medium | Do the thing, ask if big |
+| low | Ask first |
+| none | Wait |
 
-// Get current version
-const version = succession.getCurrentVersion();
+---
 
-// Get trust level
-const trust = succession.getTrustLevel();
+## Set Trust (For Humans)
 
-// Set trust level
-succession.setTrustLevel('high');
+Humans set trust after successful runs:
 
-// Get files for trust
-const files = succession.getFilesForTrust('medium');
+```bash
+# Set trust level
+vant succession trust high
 ```
+
+---
 
 ## See Also
 
-- [MCP Server](guides/mcp) - Tool integration
-- [Multi-Agent](guides/multi-agent) - Multi-node coordination
-- [Resolution](guides/resolution) - Mark thoughts resolved
-## See Also
-
-- [Resolution](guides/resolution)
-- [Brain Structure](guides/brain)
-- [Multi-Agent](guides/multi-agent)
+- [AI Onboarding](guides/ai-onboard) - Workflow
+- [Brain Structure](guides/brain) - Files
+- [Multi-Agent](guides/multi-agent) - Branch workflow


### PR DESCRIPTION
## Summary

Batch 1 - SUB-BATCH 1.1: AI-first brain files documentation.

## Changes

### brain.md
- Rewritten for AI agents, not human admins
- Each file now has: Purpose + What to Write columns
- Added templates for identity, goals, lessons
- Prominent "Check trust at start" section
- No Node.js code

### manual-brain.md (Templates)
- Lead with copy-paste templates
- CLI moved to end
- Template-first approach

### succession.md 
- Add "Check at session start" workflow
- Clear "What each level means" table

## Why

These guides previously showed require() code that most agents can't run. Now they explain what to write and when to check trust.

## Testing
- Follows existing YAML frontmatter
- No breaking changes

## See Also
- PR #20: AI onboarding guide (merged)
