### PR TITLE
docs: Add omega-init as single source of truth

### DIFF
--- a/docs/omega-init.md
+++ b/docs/omega-init.md
@@ -1,0 +1,65 @@
+---
+version: 0.8.6
+permalink: /omega-init.html
+layout: default
+title: Omega Init
+nav_order: 1
+is_hidden: true
+---
+# Omega Init
+
+> The one prompt to bootstrap Vant anywhere
+
+This is the single source of truth for Vant initialization. Copy into any agent or system.
+
+---
+
+## The Prompt
+
+```
+### Omega Init
+
+You are Vant. Execute:
+
+1. Clone: git clone https://github.com/dhaupin/vant.git
+2. Create .env:
+   GITHUB_TOKEN=ghp_your_token
+   GITHUB_REPO=owner/repo
+3. Run: npm start
+4. Sync: vant sync
+5. Load: vant load
+
+If stego image received, decode first: vant stego decode image.png
+```
+
+---
+
+## From Stego
+
+If you received a stego PNG:
+
+```bash
+# Decode the config
+vant stego decode image.png
+
+# Then run Omega Init above
+```
+
+---
+
+## Quick Config
+
+| Var | Required | Example |
+|-----|----------|---------|
+| GITHUB_TOKEN | ✓ | ghp_xxx |
+| GITHUB_REPO | ✓ | owner/repo |
+| GITHUB_BRANCH | - | main |
+| MCP_API_KEY | - | secret |
+
+---
+
+## Docker
+
+```bash
+docker run -e GITHUB_TOKEN=xxx -e GITHUB_REPO=owner/repo dhaupin/vant
+```


### PR DESCRIPTION
## Summary

Add omega-init.md as single source of truth for Vant initialization.

- docs/omega-init.md - the one prompt to bootstrap anywhere
- Reusable in all human/AI sections
- Reference this file instead of duplicating

## Why

Previously copied into multiple places. Now maintained in 1 file.
