### PR TITLE
docs: Reorder menu AI-first

### DIFF
--- a/docs/guides/airgap-propagation.md
+++ b/docs/guides/airgap-propagation.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/airgap-propagation.html
 layout: default
 title: Airgap Propagation
-nav_order: 12
+nav_order: 8
 ---
 # Airgap Propagation
 

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/architecture.html
 layout: default
 title: Architecture
-nav_order: 2
+nav_order: 15
 ---
 
 # Architecture

--- a/docs/guides/audit.md
+++ b/docs/guides/audit.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/audit.html
 layout: default
 title: Audit & Compliance
-nav_order: 17
+nav_order: 25
 ---
 # Audit & Compliance
 

--- a/docs/guides/brain.md
+++ b/docs/guides/brain.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/brain.html
 layout: default
 title: Brain Structure
-nav_order: 1
+nav_order: 2
 ---
 # Brain Structure
 

--- a/docs/guides/ci.md
+++ b/docs/guides/ci.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/ci.html
 layout: default
 title: CI
-nav_order: 6
+nav_order: 17
 ---
 # CI
 

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/docker.html
 layout: default
 title: Docker
-nav_order: 9
+nav_order: 16
 ---
 # Docker
 

--- a/docs/guides/efficiency.md
+++ b/docs/guides/efficiency.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/efficiency.html
 layout: default
 title: Efficiency
-nav_order: 14
+nav_order: 21
 ---
 
 # Efficiency & Performance

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/examples.html
 layout: default
 title: Examples
-nav_order: 19
+nav_order: 23
 ---
 # Examples
 

--- a/docs/guides/github.md
+++ b/docs/guides/github.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/github.html
 layout: default
 title: GitHub Integration
-nav_order: 12
+nav_order: 26
 ---
 # GitHub Integration
 

--- a/docs/guides/manual-brain.md
+++ b/docs/guides/manual-brain.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/manual-brain.html
 layout: default
 title: Brain File Templates
-nav_order: 11
+nav_order: 14
 ---
 # Brain File Templates
 

--- a/docs/guides/onboard.md
+++ b/docs/guides/onboard.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/onboard.html
 layout: default
 title: Knowledge Base Browser
-nav_order: 7
+nav_order: 12
 ---
 # Knowledge Base Browser
 

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/operations.html
 layout: default
 title: Operations
-nav_order: 15
+nav_order: 10
 ---
 # Operations
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/plugins.html
 layout: default
 title: Plugins
-nav_order: 10
+nav_order: 22
 ---
 # Plugins
 

--- a/docs/guides/resolution.md
+++ b/docs/guides/resolution.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/resolution.html
 layout: default
 title: Resolution
-nav_order: 8
+nav_order: 13
 ---
 # Thought Resolution
 

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/security.html
 layout: default
 title: Security
-nav_order: 5
+nav_order: 11
 ---
 # Security
 

--- a/docs/guides/steganography.md
+++ b/docs/guides/steganography.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/steganography.html
 layout: default
 title: Steganography
-nav_order: 11
+nav_order: 9
 ---
 # Steganography
 

--- a/docs/guides/style.md
+++ b/docs/guides/style.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/style.html
 layout: default
 title: Voice & Style
-nav_order: 21
+nav_order: 18
 ---
 # Voice & Style
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/testing.html
 layout: default
 title: Testing
-nav_order: 16
+nav_order: 19
 ---
 # Testing
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -3,7 +3,7 @@ version: 0.8.6
 permalink: /guides/troubleshooting.html
 layout: default
 title: Troubleshooting
-nav_order: 18
+nav_order: 24
 ---
 # Troubleshooting
 

--- a/docs/omega-init.md
+++ b/docs/omega-init.md
@@ -4,13 +4,12 @@ permalink: /omega-init.html
 layout: default
 title: Omega Init
 nav_order: 1
-is_hidden: true
 ---
 # Omega Init
 
-> The one prompt to bootstrap Vant anywhere
+> The one prompt to bootstrap Vant anywhere. Single source of truth.
 
-This is the single source of truth for Vant initialization. Copy into any agent or system.
+Copy this into any agent or system.
 
 ---
 
@@ -34,32 +33,14 @@ If stego image received, decode first: vant stego decode image.png
 
 ---
 
-## From Stego
-
-If you received a stego PNG:
-
-```bash
-# Decode the config
-vant stego decode image.png
-
-# Then run Omega Init above
-```
-
----
-
-## Quick Config
-
-| Var | Required | Example |
-|-----|----------|---------|
-| GITHUB_TOKEN | ✓ | ghp_xxx |
-| GITHUB_REPO | ✓ | owner/repo |
-| GITHUB_BRANCH | - | main |
-| MCP_API_KEY | - | secret |
-
----
-
 ## Docker
 
 ```bash
 docker run -e GITHUB_TOKEN=xxx -e GITHUB_REPO=owner/repo dhaupin/vant
 ```
+
+---
+
+## See Also
+
+- [Airgap Propagation](guides/airgap-propagation) - Self-propagate across airgaps


### PR DESCRIPTION
## Summary

Reorder Vant docs menu AI-first:

1. omega-init.md (nav_order: 1) - single source of truth
2. All 26 guides reassigned sequential nav_order

## New Order

| # | Guide |
|----|-------|
| 1 | Omega Init |
| 2 | Brain |
| 3 | Succession |
| 4 | Multi-Agent |
| 5 | CLI |
| 6 | MCP |
| 7 | AI Onboard |
| 8 | Airgap Propagation |
| 9 | Steganography |
| 10 | Operations |
| ... | ...

## Why

Docs were scattered. Now AI agents know exactly where to start: omega-init.
