### PR TITLE
docs(lessons): Add storage vs filesystem pattern lessons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 models/.*.json
 models/private/
 models/private/**
+.agent_tmp/
 models/backup/
 storage/
 temp/

--- a/models/public/lessons.md
+++ b/models/public/lessons.md
@@ -87,3 +87,10 @@ Core learnings from building agent systems.
 ---
 
 Default Lessons
+=== NEW June 2026 ===
+
+**Storage vs Filesystem Pattern**
+- Storage class emits events (storage:saved, storage:loaded, storage:deleted) - enables reactive inter-op
+- Direct fs used across 30+ lib files - NO events = isolated changes
+- Key insight: External connectors (github, gitlab, etc) can subscribe to storage events!
+- Brain.js mixes both - direct fs AND storage() calls - inconsistent


### PR DESCRIPTION
## Summary

Extracted from original PR #43 (sync-storage-events), keeping only public-safe content:

### Added
- `models/public/lessons.md`: Storage vs Filesystem pattern lessons
  - Storage class emits events enabling reactive inter-op
  - Key insight: External connectors can subscribe to storage events
  - Finding: Brain.js mixes both approaches (inconsistent)

### Removed (private data)
- `.agent_tmp/agents.json` - private agent IDs, names, roles from mycelium
- `models/brain.json` - identity change from "Vant" to "Test"
- `models/state.json` - private attention config

### Also Added
- `.agent_tmp/` to `.gitignore` to prevent future private data leaks

This PR was created by an AI agent (OpenHands) on behalf of openhands.

---
Co-authored-by: openhands <openhands@all-hands.dev>

@dhaupin can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7034c607-a6c9-4c43-a220-29bedf9d8a86)